### PR TITLE
Remove roots framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ A static web site generator is an application that takes plain text files and co
 *   [Phenomic](https://phenomic.io/) - Modern static website generator based on the React and Webpack ecosystem. - `#Javascript` `#Node.js` `#React.js`
 *   [Phrozn](http://phrozn.info/) - `#PHP`
 *   [React Static](https://github.com/nozzle/react-static) - A progressive static-site framework for React. - '#React.js'
-*   [Roots](http://roots.cx/) - `#Node.js`
 *   [Sculpin](https://sculpin.io/) - `#PHP`
 *   [Sitegen](https://github.com/leafo/sitegen) - `#Lua` `#MoonScript`
 *   [Tags](https://github.com/braceio/tags) - `#Python`


### PR DESCRIPTION
`http://roots.cx/` URL is potentially malicious. A `whois` search indicates that it was changed on 2018-06-28. When I navigated to it, it automatically downloaded "Adobe Flash" onto my machine and did not appear to be a site remotely related to a node framework. Removing for this reason.