### PR TITLE
Added MkDocs to Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A static web site generator is an application that takes plain text files and co
 *   [Orchid Javadoc](https://orchid.netlify.com/OrchidJavadoc) - Create beautiful Javadocs for your project within your Orchid site. - `#Orchid` `#Java` `#Kotlin`
 *   [Slate](https://github.com/lord/slate) - `#Ruby`
 *   [Sphinx](http://sphinx-doc.org/) - `#Python`
+*   [MkDocs](https://www.mkdocs.org/) - Write your docs in Markdown and configure the generator with a single YAML configuration file. - `#Python`
 
 ### Frameworks
 


### PR DESCRIPTION
Added MkDocs (https://www.mkdocs.org/) to Documentation.

MkDocs is a fast, simple and downright gorgeous static site generator that's geared towards building project documentation. Documentation source files are written in Markdown, and configured with a single YAML configuration file.