### PR TITLE
Remove defunct chartspree

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ A static web site generator is an application that takes plain text files and co
 
 ## Helpful Tools and Services
 
-*   [Chartspree](http://chartspree.io/) - Creates svg based charts for your static web sites.
 *   [Formspree](http://www.formspree.io/) - Adds functional forms to your static web sites.
 *   [git-annex](http://git-annex.branchable.com/tips/setup_a_public_repository_on_a_web_site/) - Configure git-annex for a public repository for a static web site.
 *   [JAMStack Themes](https://jamstackthemes.dev/) - A collection of themes filterable by static site generator and CMS support.


### PR DESCRIPTION
The chartspree link doesn't work anymore, so let's remove it.

I tried googling for chartspree to get a better link, but all I got was github repos that haven't been updated in 4-6 years.