### PR TITLE
Removing Docute

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ A static web site generator is an application that takes plain text files and co
 *   [Docsify](https://docsify.js.org/) - A magical documentation site generator. `#JavaScript` `#Node.js`
 *   [Doctave](https://github.com/Doctave/doctave) - A batteries-included developer documentation site generator. - `#Rust`
 *   [Docusaurus](https://docusaurus.io/) - Easy to maintain open source documentation websites. - `#JavaScript` `#React`
-*   [Docute](https://docute.org/) - Effortless documentation, done right. - `#JavaScript`
 *   [MkDocs](https://www.mkdocs.org/) - Write your docs in Markdown and configure the generator with a single YAML configuration file. - `#Python`
 *   [Orchid Javadoc](https://orchid.run/plugins/orchidjavadoc) - Create beautiful Javadocs for your project within your Orchid site. - `#Orchid` `#Java` `#Kotlin`
 *   [Slate](https://github.com/lord/slate) - `#Ruby`


### PR DESCRIPTION
It appears that the domain for Docute has expired and is now being parked by a website with annoying ads.