### PR TITLE
Add linkyee

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ A static web site generator is an application that takes plain text files and co
 
 *   [CMS.js](https://github.com/chrisdiana/cms.js) - A fully client-side, JavaScript Markdown site generator. - `#JavaScript`
 *   [Flatdoc](http://ricostacruz.com/flatdoc/) - A small JavaScript file that fetches Markdown files and renders them as full pages. - `#JavaScript`
+*   [linkyee](https://github.com/ZhgChgLi/linkyee) - A fully customized, open-source LinkTree alternative deployed directly on GitHub Pages. - `#Ruby`
 
 ### Tools
 


### PR DESCRIPTION
Add [linkyee](https://github.com/ZhgChgLi/linkyee)  to Sing Page tools.

A fully customized, open-source LinkTree alternative deployed directly on GitHub Pages. - `#Ruby`
