### PR TITLE
Add faircamp and pgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A static web site generator is an application that takes plain text files and co
 *   [Blag](https://github.com/venthur/blag) - blag is a blog-aware, static site generator -- it uses Markdown and is written in Python. - `#Python`
 *   [BlazorStatic](https://github.com/tesar-tech/BlazorStatic) - Use ASP.NET Blazor to generate static pages. - `#.NET` `#C#`
 *   [BlogC++](https://code.rosaelefanten.org/blogcpp/) - A static blog generator, written in C++17. - `#C++`
-*   [Bloggrify](https://bloggrify.com/) - A static blog generator using Markdown, built on top of Nuxt-Content. - `#Vue.js` `#Markdown` 
+*   [Bloggrify](https://bloggrify.com/) - A static blog generator using Markdown, built on top of Nuxt-Content. - `#Vue.js` `#Markdown`
 *   [Cobalt](https://cobalt-org.github.io) - A Rust static site generator. - `#Rust`
 *   [Coleslaw](https://github.com/coleslaw-org/coleslaw) - Flexible blog and site generator with a lot of plugins. - `#CommonLisp`
 *   [CommonMark Blog for Laravel](https://github.com/spekulatius/laravel-commonmark-blog) - Static generator to use with Laravel projects. Uses CommonMark and FrontMatter to generate and publish files in the `public`-folder. Supports articles as well as listing pages `#PHP`
@@ -169,7 +169,11 @@ A static web site generator is an application that takes plain text files and co
 *   [foto](https://github.com/waynezhang/foto) - Yet another another publishing tool for minimalist photographers. - `#Go` `#Golang`
 *   [Prosopopee](https://github.com/Psycojoker/prosopopee/) A static website generator to make beautiful customizable pictures galleries that tell a story  - `#Python`
 *   [Sigal](https://sigal.readthedocs.org/en/latest/) - `#Python`
-*
+
+### Audio
+
+*   [Faircamp](https://simonrepp.com/faircamp/) - A static site generator for audio producers. - `#Rust`
+
 ### RSS News
 -   [Liveboat](https://github.com/exaroth/liveboat) - Generate static pages from your RSS urls - `#Rust`
 
@@ -193,7 +197,7 @@ A static web site generator is an application that takes plain text files and co
 
 ## Helpful Tools and Services
 
-*   [Cloud 66](https://www.cloud66.com/) - Builds and deploys static websites to your own cloud account. 
+*   [Cloud 66](https://www.cloud66.com/) - Builds and deploys static websites to your own cloud account.
 *   [Formspree](http://www.formspree.io/) - Adds functional forms to your static web sites.
 *   [git-annex](http://git-annex.branchable.com/tips/setup_a_public_repository_on_a_web_site/) - Configure git-annex for a public repository for a static web site.
 *   [JAMStack Themes](https://jamstackthemes.dev/) - A collection of themes filterable by static site generator and CMS support.
@@ -209,6 +213,7 @@ A static web site generator is an application that takes plain text files and co
 *   [Surge](https://surge.sh/)
 *   [Vercel](https://vercel.com/)
 *   [Clouflare Pages](https://pages.cloudflare.com/)
+*   [pgs](https://pico.sh/pgs)
 
 ## Other Lists of Static Web Site Generators
 


### PR DESCRIPTION
* Added a new "Audio" section for faircamp: https://simonrepp.com/faircamp/
* Added pico's "[pgs](https://pico.sh/pgs)" to the list of web hosts
* Trimmed trailing whitespace as mentioned in `CONTRIBUTING.md`

