### PR TITLE
Remove Gridsome

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ A static web site generator is an application that takes plain text files and co
 *   [Gatsby](https://github.com/gatsbyjs/gatsby) - `#JavaScript` `#Node.js` `#React.js`
 *   [Goldsmith](https://github.com/FooSoft/goldsmith) - Fast and simple pipeline-based static site generator, extensible via plugins. `#Go`
 *   [Grain](https://github.com/sysgears/grain) - `#Groovy`
-*   [Gridsome](https://gridsome.org) - Vue.js-powered, modern site generator for building the fastest possible websites for any Headless CMS, APIs or Markdown-files. - `#Vue.js` `#JavaScript`
 *   [Hakyll](https://github.com/jaspervdj/hakyll) - Hakyll is a Haskell library for generating static sites, mostly aimed at small-to-medium sites and personal blogs. It is written in a very configurable way and uses an xmonad-like DSL for configuration. - `#Haskell`
 *   [Harp](http://harpjs.com/) - `#JavaScript` `#Node.js`
 *   [Hugo](https://github.com/spf13/hugo) - It is optimized for speed, easy use and configurability. - `#Go`


### PR DESCRIPTION
Gridsome has not been updated in three years. It should be removed to keep the list up to date.