### PR TITLE
Remove Tipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ A static web site generator is an application that takes plain text files and co
 *   [Lektor](https://www.getlektor.com/) - An easy to use static CMS and blog engine. - `#Python`
 *   [Primo](https://primo.so) - An all-in-one static site builder. - `#Svelte` `#Electron`
 *   [Publii](http://getpublii.com/) - Easy-to-use desktop app to generate static websites. - `#JavaScript` `#Electron`
-*   [Tipe](https://tipe.io/) - An easy to use API-first CMS engine to generate static sites. - `#JavaScript`
 *   [Wordmogul](https://wordmogul.com) - Minimalistic blogging platform with ZIP export of .md files (GUI for Hugo/Jekyll). - `#Go` `#Golang`
 
 ### Documentation


### PR DESCRIPTION
The website's last update seems to be a blog post from 2020, and the linked [github organization](https://github.com/tipeio) is empty.