### PR TITLE
Add ShipStatic to Web Hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ A static web site generator is an application that takes plain text files and co
 - [Kinsta Static Site Hosting](https://kinsta.com/static-site-hosting/)
 - [Netlify](https://www.netlify.com/)
 - [pgs](https://pico.sh/pgs)
+- [ShipStatic](https://shipstatic.com/) - Instant static site hosting via CLI or MCP server — no account or sign-up required.
 - [Surge](https://surge.sh/)
 - [Vercel](https://vercel.com/)
 


### PR DESCRIPTION
Adds [ShipStatic](https://shipstatic.com/) to the Web Hosts section.

ShipStatic is an instant static site hosting platform — deploy from the CLI or AI agents with no account or config required. Sits alongside Vercel, Netlify, Surge, and Cloudflare Pages.