### PR TITLE
Add StaticFeed to RSS News section

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ A static web site generator is an application that takes plain text files and co
 ### RSS News
 
 - [Liveboat](https://github.com/exaroth/liveboat) - Generate static pages from your RSS urls - `#Rust`
+- [StaticFeed](https://github.com/jackydangelo/staticfeed) - A concurrent, zero-cost RSS aggregation pipeline and static site generator powered by GitHub Actions. - `#Python`
 
 ### Single Page
 


### PR DESCRIPTION
Hi! I would like to add **StaticFeed** to the `RSS News` section of this awesome list.

StaticFeed is a concurrent static site generator and RSS aggregator that takes multiple remote RSS feeds, deduplicates them, and compiles them into a static HTML frontend alongside a unified `rss.xml` feed. 

It is designed to run entirely for free on GitHub Actions and GitHub Pages.

Thank you for maintaining this resource!