### PR TITLE
Add Hakanai Broadcast to Helpful Tools and Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ A static web site generator is an application that takes plain text files and co
 - [Fabform](https://fabform.io/) - A smart form backend service that works with all modern javascript frameworks.
 - [Formspree](http://www.formspree.io/) - Adds functional forms to your static web sites.
 - [git-annex](http://git-annex.branchable.com/tips/setup_a_public_repository_on_a_web_site/) - Configure git-annex for a public repository for a static web site.
+- [Hakanai Broadcast](https://broadcast.hakanai.io/) - Turns your site's RSS feed into an email newsletter and auto-posts new content to social networks.
 - [JAMStack Themes](https://jamstackthemes.dev/) - A collection of themes filterable by static site generator and CMS support.
 - [Statichunt](https://statichunt.com/) - An open sources directory of 700+ free themes and resources for static site generators submitted by the community.
 


### PR DESCRIPTION
Adds [Hakanai Broadcast](https://broadcast.hakanai.io/), which turns a static site's RSS feed into an email newsletter and auto-posts new content to social networks. Placed alphabetically in Helpful Tools and Services. Disclosure: I'm the maker.