### PR TITLE
Add Formspark to Helpful Tools and Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ A static web site generator is an application that takes plain text files and co
 
 - [Cloud 66](https://www.cloud66.com/) - Builds and deploys static websites to your own cloud account.
 - [Fabform](https://fabform.io/) - A smart form backend service that works with all modern javascript frameworks.
+- [Formspark](https://formspark.io/) - Point any HTML form at an endpoint and receive submissions by email and integrations, no backend to host.
 - [Formspree](http://www.formspree.io/) - Adds functional forms to your static web sites.
 - [git-annex](http://git-annex.branchable.com/tips/setup_a_public_repository_on_a_web_site/) - Configure git-annex for a public repository for a static web site.
 - [JAMStack Themes](https://jamstackthemes.dev/) - A collection of themes filterable by static site generator and CMS support.


### PR DESCRIPTION
Adds [Formspark](https://formspark.io), a form backend for static sites. Placed alphabetically between Fabform and Formspree in Helpful Tools and Services.
