### PR TITLE
Add blog.sh to Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A static web site generator is an application that takes plain text files and co
 - [BashWrite](https://github.com/RayCC51/BashWrite) - You can create a blog with a single Bash script, writing posts using extended Markdown without any dependencies. - `#Bash`
 - [Blag](https://github.com/venthur/blag) - blag is a blog-aware, static site generator -- it uses Markdown and is written in Python. - `#Python`
 - [BlazorStatic](https://github.com/tesar-tech/BlazorStatic) - Use ASP.NET Blazor to generate static pages. - `#.NET` `#C#`
+- [blog.sh](https://blogsh.app) - Posts are JSON files, the site is a static build, and comments live on the Fediverse. - `#Ruby` `#Bash`
 - [BlogC++](https://code.rosaelefanten.org/blogcpp/) - A static blog generator, written in C++17. - `#C++`
 - [Bloggrify](https://bloggrify.com/) - A static blog generator using Markdown, built on top of Nuxt-Content. - `#Vue.js` `#Markdown`
 - [Bonobo](https://github.com/rockhardandrew/bonobo) - A static site generator so simple and easy a bonobo could use it. - `C`


### PR DESCRIPTION
[blog.sh](https://blogsh.app) is a static blog generator written in Ruby (standard library only) and bash. Posts are JSON files of typed blocks, the site is a static build, and comments are Fediverse replies to each post's announcement, fetched client-side from the public API.

Source: https://github.com/DanielSnor/blog.sh (MIT, v1.0)

Added to Blogs in alphabetical order, between BlazorStatic and BlogC++, in the documented format.