### PR TITLE
Add Cactal to Web Hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ A static web site generator is an application that takes plain text files and co
 
 - [AWS S3](http://aws.amazon.com/s3/)
 - [Azure Static Web Apps](https://docs.microsoft.com/en-us/azure/static-web-apps/)
+- [Cactal](https://cactal.ai/)
 - [Cloudflare Pages](https://pages.cloudflare.com/)
 - [GitLab Pages](https://about.gitlab.com/product/pages/)
 - [Kinsta Static Site Hosting](https://kinsta.com/static-site-hosting/)


### PR DESCRIPTION
The website platform for AI agents.