### PR TITLE
Adds microfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A static web site generator is an application that takes plain text files and co
   - [Marketing](#marketing)
   - [Frameworks](#frameworks)
   - [Photography](#photography)
+  - [Portfolio](#portfolio)
   - [Single Page](#single-page)
   - [Tools](#tools)
   - [Wikis](#wikis)
@@ -197,6 +198,10 @@ A static web site generator is an application that takes plain text files and co
 - [foto](https://github.com/waynezhang/foto) - Yet another another publishing tool for minimalist photographers. - `#Go` `#Golang`
 - [Prosopopee](https://github.com/Psycojoker/prosopopee/) A static website generator to make beautiful customizable pictures galleries that tell a story - `#Python`
 - [Sigal](https://sigal.readthedocs.org/en/latest/) - `#Python`
+
+### Portfolio
+
+- [microfolio](https://github.com/aker-dev/microfolio) - A file-based static site generator for creatives to showcase their work, with grid, list and map views. - `#Svelte` `#JavaScript` `#Markdown`
 
 ### Audio / Video
 


### PR DESCRIPTION
[microfolio](https://github.com/aker-dev/microfolio) is a static site generator for creatives who want to publish their work. Content lives as Markdown files organised in folders — no database — and it ships grid, list and map views, WebP image optimisation and a dark mode. Built with SvelteKit 2 and Tailwind CSS 4; version 1.0 was released recently.

I added a new `Portfolio` section (with its entry in the table of contents) rather than filing it under an existing one: `Photography` is specific to photo galleries and `Frameworks` collects general-purpose generators, so neither really fits. Happy to move it if you'd rather not have a new section.

`npm run lint` passes.
